### PR TITLE
Moving process exit to script interface and adding tests for exit codes

### DIFF
--- a/bin/travis-artifacts
+++ b/bin/travis-artifacts
@@ -4,4 +4,4 @@ $: << File.expand_path('../../lib', __FILE__)
 
 require 'travis/artifacts'
 
-Travis::Artifacts::Cli.new(ARGV).start
+exit Travis::Artifacts::Cli.new(ARGV).start

--- a/lib/travis/artifacts/cli.rb
+++ b/lib/travis/artifacts/cli.rb
@@ -37,9 +37,10 @@ module Travis::Artifacts
     def execute_command
       if VALID_COMMANDS.include? command
         send(command)
+        return 0
       else
         STDERR.puts 'Could not find command'
-        exit 1
+        return 1
       end
     end
 

--- a/spec/travis/artifacts/cli_spec.rb
+++ b/spec/travis/artifacts/cli_spec.rb
@@ -67,5 +67,40 @@ module Travis::Artifacts
         cli.command.should == 'upload'
       end
     end
+
+    context 'with a valid command' do
+      let(:argv) { ['upload'] }
+      let(:retcode) { cli.start }
+      before { cli.stub(:upload) }
+
+      it 'returns 0' do
+        retcode.should == 0
+      end
+    end
+
+    context 'with an invalid command' do
+      let(:argv) { ['derf'] }
+      let(:retcode) { cli.start }
+
+      it 'returns 1' do
+        STDERR.stub(:puts)
+        retcode.should == 1
+      end
+
+      it 'tells us about it' do
+        STDERR.should_receive(:puts).with(/Could not find command/)
+        cli.start
+      end
+    end
+
+    context 'with an internal error' do
+      let(:argv) { ['upload'] }
+      let(:custom_error) { Class.new(Exception) }
+      before { cli.stub(:upload) { raise custom_error } }
+
+      it 'allows it to bubble up' do
+        expect { cli.start }.to raise_error(custom_error)
+      end
+    end
   end
 end


### PR DESCRIPTION
as well as asserting errors bubble up so that it's easier to ensure correct behavior for issues like #12.
