### PR TITLE
Support cloning an artifact once it reaches S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/bundle
 /log/
 /Gemfile.lock
+*.gem

--- a/bin/travis-artifacts
+++ b/bin/travis-artifacts
@@ -1,7 +1,4 @@
 #!/usr/bin/env ruby
-
 $: << File.expand_path('../../lib', __FILE__)
-
 require 'travis/artifacts'
-
 exit Travis::Artifacts::Cli.new(ARGV).start

--- a/lib/travis/artifacts/cli.rb
+++ b/lib/travis/artifacts/cli.rb
@@ -80,6 +80,10 @@ module Travis::Artifacts
             options[:target_path] = target_path
           end
 
+          opt.on('--clone-path CLONE_PATH', 'path to clone uploaded files to') do |clone_path|
+            options[:clone_path] = clone_path
+          end
+
           opt.on('--root ROOT', 'root directory for relative paths') do |root|
             options[:root] = root
           end

--- a/lib/travis/artifacts/uploader.rb
+++ b/lib/travis/artifacts/uploader.rb
@@ -60,7 +60,6 @@ module Travis::Artifacts
       begin
         _upload(file)
       rescue StandardError => e
-        puts e.inspect
         if retries < 2
           logger.info "Attempt to upload failed, retrying"
           retries += 1

--- a/lib/travis/artifacts/uploader.rb
+++ b/lib/travis/artifacts/uploader.rb
@@ -78,14 +78,14 @@ module Travis::Artifacts
     end
 
     def _clone(s3_source_path, filename)
-      destination = File.join(clone_path, filename).sub(/^\//, '')
-      logger.info "Cloning to #{destination}, public: #{@public}"
+      clone_destination = File.join(clone_path, filename).sub(/^\//, '')
+      logger.info "Cloning to #{clone_destination}, public: #{@public}"
 
       bucket.files.create({
-          :key => destination,
+          :key => clone_destination,
           :public => @public,
-          :body => "",
-          :metadata => { "etag"=>"", "x-amz-copy-source" => "#{Travis::Artifacts.bucket_name}/#{s3_source_path}" }
+          :body => '',
+          :metadata => { 'etag'=>'', 'x-amz-copy-source' => "#{Travis::Artifacts.bucket_name}/#{s3_source_path}" }
         })
     end
 

--- a/spec/travis/artifacts/cli_spec.rb
+++ b/spec/travis/artifacts/cli_spec.rb
@@ -41,7 +41,7 @@ module Travis::Artifacts
           ['upload', '--path', 'foo', '--target-path', 'bar', '--cache-control', 'public, max-age=3600', "--clone-path", 'baz']
         end
 
-        it "callls Uploader with the clone-path in addition to other parameters" do
+        it "calls Uploader with the clone-path in addition to other parameters" do
           Uploader.should_receive(:new).with(anything, hash_including(:clone_path => 'baz')).and_return double('uploader').as_null_object
 
           cli.start

--- a/spec/travis/artifacts/cli_spec.rb
+++ b/spec/travis/artifacts/cli_spec.rb
@@ -37,7 +37,15 @@ module Travis::Artifacts
       end
 
       context 'with clone path specified' do
-        pending
+        let(:argv) do
+          ['upload', '--path', 'foo', '--target-path', 'bar', '--cache-control', 'public, max-age=3600', "--clone-path", 'baz']
+        end
+
+        it "callls Uploader with the clone-path in addition to other parameters" do
+          Uploader.should_receive(:new).with(anything, hash_including(:clone_path => 'baz')).and_return double('uploader').as_null_object
+
+          cli.start
+        end
       end
 
     end

--- a/spec/travis/artifacts/cli_spec.rb
+++ b/spec/travis/artifacts/cli_spec.rb
@@ -26,7 +26,7 @@ module Travis::Artifacts
       end
 
       it 'calls Uploader with given paths, target_path, and cache_control' do
-        uploader = mock('uploader')
+        uploader = double('uploader')
         Uploader.should_receive(:new).with([Path.new('foo', nil, Dir.pwd)], \
                                           {:paths=>["foo"], :private=>false, :target_path=>"bar",
                                            :cache_control=>'public, max-age=3600'}\
@@ -35,6 +35,11 @@ module Travis::Artifacts
 
         cli.start
       end
+
+      context 'with clone path specified' do
+        pending
+      end
+
     end
 
     describe '#root' do

--- a/travis-artifacts.gemspec
+++ b/travis-artifacts.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'travis-artifacts'
-  s.version     = '0.1.0-eo2'
+  s.version     = '0.1.1'
 
   s.description = 'Travis build artifacts tools'
   s.summary     = s.description

--- a/travis-artifacts.gemspec
+++ b/travis-artifacts.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.authors     = ['admin@travis-ci.org']
   s.email       = 'admin@travis-ci.org'
 
+  s.add_dependency 'nokogiri', '< 1.6'
   s.add_dependency 'fog', '~> 1.7'
   s.add_dependency 'faraday', '~> 0.8'
   s.add_dependency 'faraday_middleware', '~> 0.9'

--- a/travis-artifacts.gemspec
+++ b/travis-artifacts.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'travis-artifacts'
-  s.version     = '0.1.0'
+  s.version     = '0.1.0-eo2'
 
   s.description = 'Travis build artifacts tools'
   s.summary     = s.description

--- a/travis-artifacts.gemspec
+++ b/travis-artifacts.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.authors     = ['admin@travis-ci.org']
   s.email       = 'admin@travis-ci.org'
 
-  s.add_dependency 'nokogiri', '< 1.6'
+  s.add_dependency 'nokogiri', '1.5.10'
   s.add_dependency 'fog', '~> 1.7'
   s.add_dependency 'faraday', '~> 0.8'
   s.add_dependency 'faraday_middleware', '~> 0.9'


### PR DESCRIPTION
This seems like a common use case given the tendency to transfer the file to a SHA specific folder, but also keep a copy of the file as "latest" to allow a consistent link to the latest build.  Given that S3 doesn't support symlinks, I think this is the next most reasonable approach.

Happy to clean this up and write tests if you would consider merging this feature.
