### PR TITLE
Bump excon version

### DIFF
--- a/travis-artifacts.gemspec
+++ b/travis-artifacts.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'nokogiri', '1.5.10'
   s.add_dependency 'fog', '1.15.0'
-  s.add_dependency 'excon', '0.25.0'
+  s.add_dependency 'excon', '0.25.1'
   s.add_dependency 'faraday', '~> 0.8'
   s.add_dependency 'faraday_middleware', '~> 0.9'
 


### PR DESCRIPTION
This solves an OpenSSL bug in Excon under JRuby: https://github.com/geemus/excon/issues/247
